### PR TITLE
refactor: fix import/exports of components, improve Skeleton show/hide logic in GifCards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,9 @@
 import { useEffect, useState } from "react";
-import { GifGrid, LoadingIndicator, Modal, Pagination } from "./components";
+import { GifGrid, Modal, Pagination } from "./components";
 import { Gif } from "./types";
 import { getTrendingGifs } from "./api";
-import { ErrorIndicator } from "./components/ErrorIndicator";
 
-import { NoResults } from "./components/NoResults";
-import * as Styles from "./app.styles";
+import * as Styled from "./app.styles";
 
 const LIMIT = 15;
 
@@ -33,26 +31,18 @@ function App() {
     fetchTrendingGifs(gifOffset);
   }, [gifOffset]);
 
+  const showPagination = loading || gifs.length > 0;
   return (
-    <Styles.AppContainer>
-      <Styles.StyledHeading>React Card Grid Challenge</Styles.StyledHeading>
-      {loading ? (
-        <Styles.MaxHeightContainer>
-          <LoadingIndicator />
-        </Styles.MaxHeightContainer>
-      ) : error ? (
-        <Styles.MaxHeightContainer>
-          <ErrorIndicator />
-        </Styles.MaxHeightContainer>
-      ) : gifs.length > 0 ? (
-        <Styles.MaxHeightContainer>
-          <GifGrid gifs={gifs} onGifClick={setSelectedGif} />
-        </Styles.MaxHeightContainer>
-      ) : (
-        <NoResults />
-      )}
-      {(loading || gifs.length > 0) && (
-        <Styles.StyledPagination>
+    <Styled.AppContainer>
+      <Styled.StyledHeading>React Card Grid Challenge</Styled.StyledHeading>
+      <GifGrid
+        loading={loading}
+        error={error}
+        gifs={gifs}
+        onGifClick={setSelectedGif}
+      />
+      {showPagination && (
+        <Styled.StyledPagination>
           <Pagination
             showPrevious={loading || gifOffset > 0}
             showNext={loading || gifOffset < 486}
@@ -63,12 +53,12 @@ function App() {
               gifOffset < 486 && setGifOffset(gifOffset + LIMIT)
             }
           />
-        </Styles.StyledPagination>
+        </Styled.StyledPagination>
       )}
       {selectedGif && (
         <Modal gif={selectedGif} onClose={() => setSelectedGif(null)} />
       )}
-    </Styles.AppContainer>
+    </Styled.AppContainer>
   );
 }
 

--- a/src/app.styles.ts
+++ b/src/app.styles.ts
@@ -10,12 +10,6 @@ export const AppContainer = styled.div`
   padding: 2rem;
 `;
 
-export const MaxHeightContainer = styled.div`
-  overflow: scroll;
-  width: 100%;
-  flex: 1 1 auto;
-`;
-
 export const StyledHeading = styled.h1`
   font-size: 2rem;
   font-weight: 700;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -13,9 +13,11 @@ export const Card: FC<CardProps> = ({ gif, onClick }) => {
   const [isLoaded, setIsLoaded] = useState(false);
   return (
     <Styled.Card onClick={() => onClick(gif)}>
-      <Styled.SkeletonContainer className={isLoaded ? "loaded" : ""}>
-        <SkeletonLoader />
-      </Styled.SkeletonContainer>
+      {!isLoaded && (
+        <Styled.SkeletonContainer>
+          <SkeletonLoader />
+        </Styled.SkeletonContainer>
+      )}
       <Styled.Image
         src={gif.images.fixed_width.url}
         alt={gif.title}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,6 +1,6 @@
 import { FC, useState } from "react";
 import { Gif } from "../types";
-import SkeletonLoader from "./SkeletonLoader";
+import { SkeletonLoader } from "./";
 
 import * as Styled from "./card.styles";
 

--- a/src/components/GifGrid.tsx
+++ b/src/components/GifGrid.tsx
@@ -1,20 +1,42 @@
 import { FC } from "react";
 import { Gif } from "../types";
-import { Card } from "./Card";
+import { Card, ErrorIndicator, LoadingIndicator, NoResults } from "./";
 
 import * as Styled from "./gifGrid.styles";
 
 interface GifGridProps {
+  loading: boolean;
+  error: boolean;
   gifs: Gif[];
   onGifClick: (gif: Gif) => void;
 }
 
-export const GifGrid: FC<GifGridProps> = ({ gifs, onGifClick }) => {
+export const GifGrid: FC<GifGridProps> = ({
+  loading,
+  error,
+  gifs,
+  onGifClick,
+}) => {
+  const hasNoResults = gifs.length === 0 && !loading && !error;
   return (
-    <Styled.GifGrid>
-      {gifs.map((gif) => (
-        <Card key={gif.id} gif={gif} onClick={onGifClick} />
-      ))}
-    </Styled.GifGrid>
+    <>
+      {hasNoResults ? (
+        <NoResults />
+      ) : (
+        <Styled.MaxHeightContainer>
+          {loading ? (
+            <LoadingIndicator />
+          ) : error ? (
+            <ErrorIndicator />
+          ) : (
+            <Styled.GifGrid>
+              {gifs.map((gif) => (
+                <Card key={gif.id} gif={gif} onClick={onGifClick} />
+              ))}
+            </Styled.GifGrid>
+          )}
+        </Styled.MaxHeightContainer>
+      )}
+    </>
   );
 };

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import SkeletonLoader from "./SkeletonLoader";
+import { SkeletonLoader } from "./";
 
 import * as Styled from "./loadingIndicator.styles";
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useRef, KeyboardEvent, useState } from "react";
 import { Gif } from "../types";
 import { CloseIcon } from "../assets/icons";
-import SkeletonLoader from "./SkeletonLoader";
+import { SkeletonLoader } from "./";
 
 import * as Styled from "./modal.styles";
 

--- a/src/components/SkeletonLoader.tsx
+++ b/src/components/SkeletonLoader.tsx
@@ -1,5 +1,5 @@
 import * as Styled from "./skeletonLoader.styles";
 
-export default function SkeletonLoader() {
+export const SkeletonLoader = () => {
   return <Styled.SkeletonLoader />;
-}
+};

--- a/src/components/card.styles.ts
+++ b/src/components/card.styles.ts
@@ -30,9 +30,6 @@ export const SkeletonContainer = styled.div`
   z-index: 1;
   width: 100%;
   height: 60%;
-  &.loaded {
-    display: none;
-  }
 `;
 
 export const Title = styled.div`

--- a/src/components/gifGrid.styles.ts
+++ b/src/components/gifGrid.styles.ts
@@ -7,3 +7,9 @@ export const GifGrid = styled.div`
   justify-items: center;
   padding: 16px;
 `;
+
+export const MaxHeightContainer = styled.div`
+  overflow-y: scroll;
+  width: 100%;
+  flex: 1 1 auto;
+`;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,7 +1,19 @@
 import { Card } from "./Card";
+import { ErrorIndicator } from "./ErrorIndicator";
 import { GifGrid } from "./GifGrid";
 import { LoadingIndicator } from "./LoadingIndicator";
 import { Modal } from "./Modal";
+import { NoResults } from "./NoResults";
 import { Pagination } from "./Pagination";
+import { SkeletonLoader } from "./SkeletonLoader";
 
-export { Card, GifGrid, LoadingIndicator, Modal, Pagination };
+export {
+  Card,
+  GifGrid,
+  LoadingIndicator,
+  Modal,
+  Pagination,
+  ErrorIndicator,
+  NoResults,
+  SkeletonLoader,
+};


### PR DESCRIPTION
- refactor: fixed the exports of components to come from the `./index.ts` file and all other components to import using ` import { ABC, DEF .... } from './components' for cleaner imports
- Optimized the logic for showing/hiding skeletons until images are loaded in the `GifGrid -> Cards`
 - use JS conditional rendering and move away from altering the `display` property in css