### PR TITLE
fixes: modal styling, AppContainer and cards limit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,19 +5,21 @@ import { getTrendingGifs } from "./api";
 
 import * as Styled from "./app.styles";
 
-const LIMIT = 15;
+const LARGE_SCREEN_LIMIT = 50;
+const SMALL_SCREEN_LIMIT = 21;
 
 function App() {
+  const [limit, setLimit] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
   const [gifs, setGifs] = useState<Gif[]>([]);
   const [gifOffset, setGifOffset] = useState(0);
   const [selectedGif, setSelectedGif] = useState<Gif | null>(null);
 
-  const fetchTrendingGifs = async (offset: number) => {
+  const fetchTrendingGifs = async (offset: number, limit: number) => {
     setLoading(true);
     try {
-      const response = await getTrendingGifs({ offset, limit: LIMIT });
+      const response = await getTrendingGifs({ offset, limit });
       setGifs(response.data);
     } catch (error) {
       console.error("Error fetching trending gifs:", error);
@@ -28,14 +30,32 @@ function App() {
   };
 
   useEffect(() => {
-    fetchTrendingGifs(gifOffset);
-  }, [gifOffset]);
+    const handleResize = () => {
+      if (window.innerWidth > 1919) {
+        setLimit(LARGE_SCREEN_LIMIT);
+      } else {
+        setLimit(SMALL_SCREEN_LIMIT);
+      }
+    };
+    handleResize();
+
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  useEffect(() => {
+    // skip api call before mount is complete
+    if (limit !== 0) fetchTrendingGifs(gifOffset, limit);
+  }, [gifOffset, limit]);
 
   const showPagination = loading || gifs.length > 0;
   return (
     <Styled.AppContainer>
       <Styled.StyledHeading>React Card Grid Challenge</Styled.StyledHeading>
       <GifGrid
+        limit={limit}
         loading={loading}
         error={error}
         gifs={gifs}
@@ -47,10 +67,10 @@ function App() {
             showPrevious={loading || gifOffset > 0}
             showNext={loading || gifOffset < 486}
             onClickPrevious={() =>
-              gifOffset > 0 && setGifOffset(Math.max(0, gifOffset - LIMIT))
+              gifOffset > 0 && setGifOffset(Math.max(0, gifOffset - limit))
             }
             onClickNext={() =>
-              gifOffset < 486 && setGifOffset(gifOffset + LIMIT)
+              gifOffset < 486 && setGifOffset(gifOffset + limit)
             }
           />
         </Styled.StyledPagination>

--- a/src/app.styles.ts
+++ b/src/app.styles.ts
@@ -7,6 +7,8 @@ export const AppContainer = styled.div`
   justify-content: center;
   gap: 1rem;
   height: 90vh;
+  max-width: 1920px;
+  margin: 0 auto;
   padding: 2rem;
 `;
 

--- a/src/components/GifGrid.tsx
+++ b/src/components/GifGrid.tsx
@@ -5,6 +5,7 @@ import { Card, ErrorIndicator, LoadingIndicator, NoResults } from "./";
 import * as Styled from "./gifGrid.styles";
 
 interface GifGridProps {
+  limit: number;
   loading: boolean;
   error: boolean;
   gifs: Gif[];
@@ -12,6 +13,7 @@ interface GifGridProps {
 }
 
 export const GifGrid: FC<GifGridProps> = ({
+  limit,
   loading,
   error,
   gifs,
@@ -25,7 +27,7 @@ export const GifGrid: FC<GifGridProps> = ({
       ) : (
         <Styled.MaxHeightContainer>
           {loading ? (
-            <LoadingIndicator />
+            <LoadingIndicator limit={limit} />
           ) : error ? (
             <ErrorIndicator />
           ) : (

--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,16 +1,17 @@
-import { FC } from "react";
+import { FC, useMemo } from "react";
 import { SkeletonLoader } from "./";
 
 import * as Styled from "./loadingIndicator.styles";
 
-export const LoadingIndicator: FC = () => {
+export const LoadingIndicator: FC<{ limit: number }> = ({ limit }) => {
+  const loadingSkeletonsList = useMemo(() => {
+    return new Array(limit).fill(0).map((_, index) => (
+      <Styled.SkeletonLoaderContainer key={index}>
+        <SkeletonLoader />
+      </Styled.SkeletonLoaderContainer>
+    ));
+  }, [limit]);
   return (
-    <Styled.LoadingContainer>
-      {new Array(15).fill(0).map((_, index) => (
-        <Styled.SkeletonLoaderContainer key={index}>
-          <SkeletonLoader />
-        </Styled.SkeletonLoaderContainer>
-      ))}
-    </Styled.LoadingContainer>
+    <Styled.LoadingContainer>{loadingSkeletonsList}</Styled.LoadingContainer>
   );
 };

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -95,9 +95,11 @@ export const Modal: FC<ModalProps> = ({ gif, onClose }) => {
           </Styled.CloseButton>
         </Styled.Header>
         <Styled.Divider />
-        <Styled.SkeletonContainer className={imageLoaded ? "loaded" : ""}>
-          <SkeletonLoader />
-        </Styled.SkeletonContainer>
+        {!imageLoaded && (
+          <Styled.SkeletonContainer>
+            <SkeletonLoader />
+          </Styled.SkeletonContainer>
+        )}
         <Styled.Gif
           className={imageLoaded ? "loaded" : ""}
           src={gif.images.original.url}

--- a/src/components/modal.styles.ts
+++ b/src/components/modal.styles.ts
@@ -22,7 +22,8 @@ export const ModalContent = styled.div`
   flex-direction: column;
   align-items: center;
   position: relative;
-  width: 80%;
+  max-height: 80%;
+  max-width: 80%;
   background-color: #fefefe;
   margin: auto;
   padding: 20px;
@@ -72,7 +73,7 @@ export const Gif = styled.img`
   aspect-ratio: 1/1;
   border-radius: 1rem;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-  margin: 1rem 0;
+  margin: auto 0;
   visibility: hidden;
   max-width: 480px;
   &.loaded {
@@ -86,9 +87,6 @@ export const SkeletonContainer = styled.div`
   max-width: 480px;
   padding: 1rem 0;
   aspect-ratio: 1/1;
-  &.loaded {
-    display: none;
-  }
 `;
 
 export const SROnly = styled.span`


### PR DESCRIPTION
### Refactoring
- Adjust modal height and width
- Adjust skeleton rendering logic to use `conditional rendering` rather than `css display` property

### Improvements
- Better UI experience on different screens by adjusting the limit for max no. of cards
- Add resize observer to dynamically adjust limit based on specific screen breakpoints

### Fixes
- Restrict `max-width` of the `AppContainer` to ensure the content looks neat and remains aligned centrally on larger screens too