### PR TITLE
fixes: logical fix in App.tsx, styling fix in Modal -> Close Button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,9 +21,11 @@ function App() {
     try {
       const response = await getTrendingGifs({ offset, limit });
       setGifs(response.data);
+      setError(false);
     } catch (error) {
       console.error("Error fetching trending gifs:", error);
       setError(true);
+      setGifs([]);
     } finally {
       setLoading(false);
     }

--- a/src/components/modal.styles.ts
+++ b/src/components/modal.styles.ts
@@ -46,6 +46,7 @@ export const Title = styled.h2`
 `;
 
 export const CloseButton = styled.button`
+  display: flex;
   cursor: pointer;
   color: #000;
   background: none;


### PR DESCRIPTION
### Fixes:
- Add the following missing state resets in `App.tsx`
  -  Reset `errors` when api fetches gifs successfully
  -  Reset `gifs` when api fails with an error
- Adjust modal close button icon alignment, `center-align` close icon