### PR TITLE
chores: add example env file and start command for dev server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_GIPHY_API_KEY=abcd1234 # replace this with your Giphy API key, which you can get from https://developers.giphy.com/
+VITE_GIPHY_API_URL=https://api.giphy.com/v1/gifs

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "start": "vite",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",


### PR DESCRIPTION
### Chores:
- added `env.example` for a quick reference on setting up `env` variables
- added conventional `start` command in `package.json` to allow running dev server through `npm start`